### PR TITLE
Revert "Get rid of using Playframework's WS in MabxmlApplication.get()"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ target
 tmp
 .history
 dist
-web/data
 web/out
 web/.classpath
 web/.project

--- a/web/build.sbt
+++ b/web/build.sbt
@@ -8,6 +8,5 @@ scalaVersion := "2.11.1"
 
 libraryDependencies ++= Seq(
   cache,
-  javaWs,
-  "org.elasticsearch" % "elasticsearch" % "1.3.6"
+  javaWs
 )


### PR DESCRIPTION
Reverts hbz/mabxml-elasticsearch#8

The change ignores the server location in the config file and always uses a local ES instance.

The previous implementation using WS worked fine, so I suggest this plain revert.