### PR TITLE
436 enable weekly full indexing

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -12,12 +12,13 @@ DATE=$(date "+%Y%m%d")
 DATE_YESTERDAY=$(date --date yesterday "+%Y%m%d")
 
 DOWNLOAD_FILE="DE-605-aleph-update-marcxchange-$DATE_YESTERDAY-$DATE.tar.gz"
+# Use "brace extension" as we don't know the appendix of the basedump
 if [ $1 == "basedump" ]; then
-	DOWNLOAD_FILE="DE-605-aleph-baseline-marcxchange-$DATE.tar.gz"
+	DOWNLOAD_FILE="DE-605-aleph-baseline-marcxchange-$DATE{00..24}.tar.gz"
 fi
 
 cd $TARGET_PATH 
-wget -nv http://lobid.org/download/dumps/DE-605/mabxml/$DOWNLOAD_FILE
+eval wget -nv http://lobid.org/download/dumps/DE-605/mabxml/$DOWNLOAD_FILE || true
 
 cd ..
 # Run the transformation with the latest file (and possibly unprocessed previous files):


### PR DESCRIPTION
As we don't know the exact suffix of the basedump file the "brace extension"
is used. This pattern expands and using "eval" all permutations are tried
to wget. Because this will fail often, the "|| true" allows to have nonzero
exit status.

Complements hbz/lobid-resources#436.