### PR TITLE
Use other directory when indexing weekly basedump

### DIFF
--- a/cron.sh
+++ b/cron.sh
@@ -15,6 +15,7 @@ DOWNLOAD_FILE="DE-605-aleph-update-marcxchange-$DATE_YESTERDAY-$DATE.tar.gz"
 # Use "brace extension" as we don't know the appendix of the basedump
 if [ $1 == "basedump" ]; then
 	DOWNLOAD_FILE="DE-605-aleph-baseline-marcxchange-$DATE{00..24}.tar.gz"
+ 	TARGET_PATH=weekly	
 fi
 
 cd $TARGET_PATH 


### PR DESCRIPTION
Since the indexing of the complete basedump takes more than 24h
the temporary stored basedump file will be removed by the daily
indexing routine. To avoid this a special directory is used which
won't be cleansed by daily update processes.

See hbz/lobid-resources#436.