### PR TITLE
Add mail script, fix build, move to Metafacture 5.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,10 @@
-sudo: false
-language: java
+language: scala
+scala: 2.11.12
 jdk: oraclejdk8
+dist: trusty
 env:
-  - ACTIVATOR_VERSION=1.3.9 ELASTICSEARCH_VERSION=5.6.3
-before_install:
-  - git clone https://github.com/hbz/metafacture-core.git
-  - cd metafacture-core
-  - mvn clean install -DskipTests=true
-  - cd ..
-  - wget http://downloads.typesafe.com/typesafe-activator/${ACTIVATOR_VERSION}/typesafe-activator-${ACTIVATOR_VERSION}-minimal.zip
-  - unzip typesafe-activator-${ACTIVATOR_VERSION}-minimal.zip
-  - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.zip
-  - unzip elasticsearch-${ELASTICSEARCH_VERSION}.zip
-  - cd elasticsearch-${ELASTICSEARCH_VERSION}
-  - bin/elasticsearch -d
-  - cd ..
-  - sleep 10
-script:
-  - activator-${ACTIVATOR_VERSION}-minimal/bin/activator test
+  - ES_VERSION=5.6.16 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+install:
+  - wget ${ES_DOWNLOAD_URL}
+  - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
+  - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &

--- a/README.textile
+++ b/README.textile
@@ -6,18 +6,11 @@ h1. Setup
 
 "!https://secure.travis-ci.org/hbz/mabxml-elasticsearch.png?branch=master!":https://travis-ci.org/hbz/mabxml-elasticsearch
 
-Prerequisites: Maven 3 with Java 8 and UTF-8 encoding; verify with @mvn -version@
+Prerequisites: Java 8; verify with @java -version@
 
-Create and change into a folder where you want to store the projects:
+Create and change into a folder where you want to store the project:
 
 * @mkdir ~/git ; cd ~/git@
-
-Build the hbz metafacture-core fork:
-
-* @git clone https://github.com/hbz/metafacture-core.git@
-* @cd metafacture-core@
-* @mvn clean install -DskipTests@
-* @cd ..@
 
 Get and change into the mabxml-elasticsearch repo:
 
@@ -30,13 +23,13 @@ h2. Index server setup
 
 See also: "Elasticsearch installation steps":https://www.elastic.co/downloads/elasticsearch.
 
-Download the latest 2.3.x Elasticsearch release, e.g. on Linux:
+Download the latest 5.6.x Elasticsearch release, e.g. on Linux:
 
-@wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-2.3.3.zip@
+@wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.16.zip@
 
 Unzip it and change into the new directory:
 
-@unzip elasticsearch-2.3.3.zip ; cd elasticsearch-2.3.3@
+@unzip elasticsearch-5.6.16.zip ; cd elasticsearch-5.6.16@
 
 Run the @elasticsearch@ application in the @bin/@ folder in daemon mode (output is logged to @logs/elasticsearch.log@), and record the process id:
 

--- a/app/data/ElasticsearchIndexer.java
+++ b/app/data/ElasticsearchIndexer.java
@@ -8,10 +8,10 @@ import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.culturegraph.mf.framework.DefaultObjectPipe;
-import org.culturegraph.mf.framework.ObjectReceiver;
-import org.culturegraph.mf.framework.annotations.In;
-import org.culturegraph.mf.framework.annotations.Out;
+import org.metafacture.framework.helpers.DefaultObjectPipe;
+import org.metafacture.framework.ObjectReceiver;
+import org.metafacture.framework.annotations.In;
+import org.metafacture.framework.annotations.Out;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.client.Client;

--- a/app/data/IdExtractor.java
+++ b/app/data/IdExtractor.java
@@ -14,10 +14,10 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import org.culturegraph.mf.framework.DefaultObjectPipe;
-import org.culturegraph.mf.framework.StreamReceiver;
-import org.culturegraph.mf.framework.annotations.In;
-import org.culturegraph.mf.framework.annotations.Out;
+import org.metafacture.framework.helpers.DefaultObjectPipe;
+import org.metafacture.framework.StreamReceiver;
+import org.metafacture.framework.annotations.In;
+import org.metafacture.framework.annotations.Out;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;

--- a/app/data/Transform.java
+++ b/app/data/Transform.java
@@ -3,11 +3,11 @@
 
 package data;
 
-import org.culturegraph.mf.stream.converter.JsonEncoder;
-import org.culturegraph.mf.stream.pipe.ObjectLogger;
-import org.culturegraph.mf.stream.source.DirReader;
-import org.culturegraph.mf.stream.source.FileOpener;
-import org.culturegraph.mf.stream.source.TarReader;
+import org.metafacture.json.JsonEncoder;
+import org.metafacture.monitoring.ObjectLogger;
+import org.metafacture.files.DirReader;
+import org.metafacture.io.FileOpener;
+import org.metafacture.io.TarReader;
 
 /**
  * Index MAB XML clobs into an Elasticsearch instance.

--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,16 @@ version := "1.1-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-scalaVersion := "2.11.1"
+scalaVersion := "2.11.12"
 
 libraryDependencies ++= Seq(
   cache,
   javaWs,
-  "org.culturegraph" % "metafacture-core" % "4.0.0-HBZ-SNAPSHOT"
-    exclude("com.fasterxml.jackson.core", "jackson-core"),
+  "org.metafacture" % "metafacture-framework" % "5.1.0",
+  "org.metafacture" % "metafacture-json" % "5.1.0",
+  "org.metafacture" % "metafacture-monitoring" % "5.1.0",
+  "org.metafacture" % "metafacture-files" % "5.1.0",
+  "org.metafacture" % "metafacture-io" % "5.1.0",
   "org.slf4j" % "slf4j-log4j12" % "1.7.6",
   "org.elasticsearch" % "elasticsearch" % "5.6.3",
   "org.elasticsearch.client" % "transport" % "5.6.3",

--- a/cron.sh
+++ b/cron.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -euo pipefail # See http://redsymbol.net/articles/unofficial-bash-strict-mode/
+# explicitly without "-e" for it should not exit immediately when failed but write a mail
+set -uo pipefail # See http://redsymbol.net/articles/unofficial-bash-strict-mode/
 IFS=$'\n\t'
 
 # Execute via crontab by hduser@weywot1:
@@ -9,6 +10,8 @@ IFS=$'\n\t'
 TARGET_PATH=/data/DE-605/mabxml
 # Determine the latest update file and store it locally:
 DATE=$(date "+%Y%m%d")
+
+RECIPIENT=lobid-admin
 
 # Use "brace extension" as we don't know the appendix of the basedump
 if [ $1 == "basedump" ]; then
@@ -20,5 +23,12 @@ fi
 # Run the transformation with the latest file (and possibly unprocessed previous files):
 curl --fail -XPOST "http://localhost:7300/hbz01/transform?dir=$TARGET_PATH&suffix=gz&cluster=weywot&hostname=10.9.0.12&index=hbz01" >> logs/processMabxml.sh.$DATE-weywot.log 2>&1
 
+# if check ok, index to productive instance:
+if [  $? -ne 0 ]; then
+    mail -s "Alert MAB-XML Clobs indexing to hbz01" "$RECIPIENT@hbz-nrw.de" << EOF
+"error when indexing MAB-XML Clobs to index hbz01 :("
+EOF
+else
 # Clean up
-rm $TARGET_PATH/*.gz
+  rm $TARGET_PATH/*.gz
+fi

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Mon Dec 08 18:02:27 CET 2014
 template.uuid=b8c48296-17e1-4a16-bc6d-2d69e7ae8057
-sbt.version=0.13.5
+sbt.version=0.13.18


### PR DESCRIPTION
This is basically a clean version of the things I tried and reverted in https://github.com/hbz/mabxml-elasticsearch/pull/53 plus move to Metafacture 5.1.0.

@dr0i, I've cherry-picked your commits for the mail script and the SBT version bump, and moved the project to the published 5.1.0 version of Metafacture (so no more checkout of the hbz fork etc). Also bumped the Elasticsearch version (from 5.6.3 to 5.6.16 in Travis, and from 2.3.3 to 5.6.16 in the README).